### PR TITLE
Adding LD_LIBRARY_PATH tip for Ubuntu users

### DIFF
--- a/c/index.html
+++ b/c/index.html
@@ -113,7 +113,11 @@ lead: Install and start using the igraph library
         <p>The <code>make check</code> step is optional, but it is
           useful to spot problems early on.
         </p>
-
+        <p>For Ubuntu users: If you receive an <code>ImportError</code> when
+          using the igraph library, you may be able to fix the issue by adding
+          <code>export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"</code>
+          to your <code>~/.bashrc</code> file.
+        </p>
         <h3><span id="cinstallosx" class="anchor">&nbsp;</span>
           Installation on Mac OS X</h3>
         <p>


### PR DESCRIPTION
Per Tamas suggestion on igraph-help listserv, 2015-02-18. There are multiple work-arounds for the issue with Ubuntu, but this one works and Ubuntu is a popular enough distribution that it's maybe worth mentioning on the web page. Note: I agree to license this contribution under igraph's licensing terms.