### PR TITLE
Fix a typo in igraph tutorial

### DIFF
--- a/docs/python/doc/tutorial/tutorial.html
+++ b/docs/python/doc/tutorial/tutorial.html
@@ -405,7 +405,7 @@ answer can quickly be given by checking the degree distributions of the two grap
 <p><em>igraph</em> uses vertex and edge IDs in its core. These IDs are integers, starting from zero,
 and they are always continuous at any given time instance during the lifetime of the graph.
 This means that whenever vertices and edges are deleted, a large set of edge and possibly
-vertex IDs will be renumbered to ensure the continuiuty. Now, let us assume that our graph
+vertex IDs will be renumbered to ensure the continuity. Now, let us assume that our graph
 is a social network where vertices represent people and edges represent social connections
 between them. One way to maintain the association between vertex IDs and say, the corresponding
 names is to have an additional Python list that maps from vertex IDs to names. The drawback


### PR DESCRIPTION
continuiuty -> continuity

Really excellent library and documentation, btw.  Thanks!