### PR TITLE
Update part of website 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ $(PY)/stamp:
 core: stamp
 
 HTML= index.html news.html _layouts/default.html \
-	_layouts/manual.html c/index.html \
+	_layouts/manual.html c/index.html c/compilation-windows.html \
 	r/index.html python/index.html
 
 CSS= css/affix.css css/manual.css css/other.css fonts/fonts.css

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -5,26 +5,7 @@ The igraph homepage is built using Jekyll. Install
 [Jekyll](https://jekyllrb.com) if you don't have it yet. Further requirements
 are listed below.
 
-You need so install the following RubyGems (e.g. using `gem install`):
-- `addressable-2.6.0`
-- `bundler-2.1.4`
-- `concurrent-ruby-1.1.5`
-- `eventmachine-1.2.7`
-- `ffi-1.10.0`
-- `i18n-0.9.5`
-- `rb-fsevent-0.10.3`
-- `rb-inotify-0.10.0`
-- `sass-listen-4.0.0`
-- `sass-3.7.4`
-- `ruby_dep-1.5.0`
-- `jekyll-watch-2.2.1`
-- `liquid-4.0.3`
-- `pathutil-0.16.2`
-- `safe_yaml-1.0.5`
-- `jekyll-3.8.5`
-- `jekyll-sitemap-1.3.1`
-- `multi_json-1.13.1`
-- `pygments.rb-1.2.1`
+You need so install RubyGems using `gem install`.
 
 The homepage itself will be built in `docs/`. The contents of `docs/` is exactly
 the same as what is shown at `igraph.org`. Instead of running Jekyll manually,

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -5,6 +5,27 @@ The igraph homepage is built using Jekyll. Install
 [Jekyll](https://jekyllrb.com) if you don't have it yet. Further requirements
 are listed below.
 
+You need so install the following RubyGems (e.g. using `gem install`):
+- `addressable-2.6.0`
+- `bundler-2.1.4`
+- `concurrent-ruby-1.1.5`
+- `eventmachine-1.2.7`
+- `ffi-1.10.0`
+- `i18n-0.9.5`
+- `rb-fsevent-0.10.3`
+- `rb-inotify-0.10.0`
+- `sass-listen-4.0.0`
+- `sass-3.7.4`
+- `ruby_dep-1.5.0`
+- `jekyll-watch-2.2.1`
+- `liquid-4.0.3`
+- `pathutil-0.16.2`
+- `safe_yaml-1.0.5`
+- `jekyll-3.8.5`
+- `jekyll-sitemap-1.3.1`
+- `multi_json-1.13.1`
+- `pygments.rb-1.2.1`
+
 The homepage itself will be built in `docs/`. The contents of `docs/` is exactly
 the same as what is shown at `igraph.org`. Instead of running Jekyll manually,
 you should call:

--- a/c/compilation-windows.html
+++ b/c/compilation-windows.html
@@ -8,7 +8,7 @@ lead: Compile using <code>msys2</code> or MSVC.
 
   <div id="readme">
 
-    <p>There are two ways to compile igraph on Windows. You can either build from the released source code, or you can
+    <p>There are two ways to compile <code>igraph</code> on Windows. You can either build from the released source code, or you can
       build from the <code>git</code> repository. Compiling from the released source code is sometimes easier, as it
       already provides a project file that can be used to compile with Microsoft Visual C++ (MSVC). Of course,
       compilation from the released source code is limited to released versions, while compilation from the
@@ -60,7 +60,7 @@ lead: Compile using <code>msys2</code> or MSVC.
     </ul>
     <p>The <code>mingw-w64-x86_64-toolchain</code> also includes the optional <a href="https://gmplib.org/"
         rel="nofollow">Gnu Multiple Precision</a> package <code>mingw-w64-x86_64-gmp</code>. This enables extended
-      functionality in igraph.</p>
+      functionality in <code>igraph</code>.</p>
     <p>You can install these packages by running the following command in an <code>msys2</code> terminal:</p>
     <pre><code>pacman -S autoconf automake bison flex libtool make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libxml2 mingw-w64-x86_64-gmp git zip
 </code></pre>
@@ -99,7 +99,7 @@ make
     <h2><a id="user-content-preparing-the-msvc-project-file" class="anchor" 
         href="#preparing-the-msvc-project-file"></a>Preparing the MSVC project file</h2>
     <p>If you intend to compile with Microsoft Visual C++, you will need a project file for Microsoft Visual C++. This
-      can be done by following the above steps, except for the last step, you create the MSVC project file using</p>
+      can be done by following the above steps, except for the last step, and then creating the MSVC project file using</p>
     <pre><code>./configure
 make msvc
 </code></pre>
@@ -113,13 +113,13 @@ make msvc
         href="https://wiki.python.org/moin/WindowsCompilers" rel="nofollow">the Python website</a> for more details.</p>
     <p>The provided project file is still provided in an older MSVC format. To use it with more recent versions of MSVC,
       you will have to upgrade the project file. Note that this can only be done if you have the the full Microsoft
-      Visual Studio install. You can install the Community edition, which is <a
-        href="https://visualstudio.microsoft.com/downloads/" rel="nofollow">freely available</a>. The Build Tools that
+      Visual Studio installed. You can install the Community edition, which is <a
+        href="https://visualstudio.microsoft.com/downloads/" rel="nofollow">freely available</a>. The Microsoft Visual C++ Build Tools that
       are available do not allow you to upgrade the project file, which is necessary to be able to compile
       <code>igraph</code> correctly.</p>
-    <p>Compilation can be done in two ways. The easiest way for most users is probably simply to open the project
+    <p>Compilation can be done in two ways. The easiest way for most users is to open the project
       solution file (<code>igraph.sln</code>) in the Visual Studio IDE. It will ask you to convert it to the current
-      format, and you should be able to compile it, once that is done.</p>
+      format, and you should be able to compile it, once it is converted.</p>
     <p>Alternatively, you can compile via the command line. In that case, open the "Developer Command Prompt", and
       depending on your version of MSVC, you should do the following</p>
     <p>MSVC 9.0</p>
@@ -141,7 +141,7 @@ msbuild.exe igraph.vcxproj
     <p>before you include</p>
     <pre><code>#include "igraph.h"
 </code></pre>
-    <p>Alternatively, you can also reconfigure the MSVC project to compile a dynamic library (<code>.dll</code>), in
+    <p>Alternatively, you can reconfigure the MSVC project to compile a dynamic library (<code>.dll</code>), in
       which case the <code>IGRAPH_STATIC</code> definition should <em>not</em> be included.</p>
     <p>A small test project is included in the <code>igraphtest</code> subdirectory of the
       <code>igraph-[VERSION]-msvc</code> directory.</p>

--- a/c/compilation-windows.html
+++ b/c/compilation-windows.html
@@ -1,0 +1,155 @@
+---
+layout: default
+mainheader: Compiling the igraph library in Windows
+lead: Compile using <code>msys2</code> or MSVC.
+---
+
+<div class="container">
+
+  <div id="readme">
+
+    <p>There are two ways to compile igraph on Windows. You can either build from the released source code, or you can
+      build from the <code>git</code> repository. Compiling from the released source code is sometimes easier, as it
+      already provides a project file that can be used to compile with Microsoft Visual C++ (MSVC). Of course,
+      compilation from the released source code is limited to released versions, while compilation from the
+      <code>git</code> repository allows you to also compile development versions. Compilation can always be done using
+      MinGW, but if you want to use <code>igraph</code> with Python (e.g. as an external library for
+      <code>python-igraph</code>) you have to use MSVC. Each Python version requires a specific version of MSVC, please
+      see the Python <a href="https://wiki.python.org/moin/WindowsCompilers" rel="nofollow">website</a> for more
+      details. Preparing a project file to compile with MSVC is again done using MinGW (<code>msys2</code>).</p>
+    <p>In summary, there are two routes to compiling <code>igraph</code>:</p>
+    <ol>
+      <li>Compile using <code>msys2</code></li>
+      <li>Compile using Microsoft Visual C++
+        <ul>
+          <li>If no project file is provided, this should be generated using <code>msys2</code>.</li>
+        </ul>
+      </li>
+    </ol>
+    <p>More detailed instructions are provided below.</p>
+
+    <h1><a id="user-content-compilation-using-msys2" class="anchor" 
+        href="#compilation-using-msys2"></a>Compilation using <code>msys2</code></h1>
+    <h2><a id="user-content-configuration-of-msys2" class="anchor" 
+        href="#configuration-of-msys2"></a>Installation and configuration of <code>msys2</code></h2>
+    <p>We recommend to use <a href="https://www.msys2.org/" rel="nofollow"><code>msys2</code></a> to compile
+      <code>igraph</code>, because it includes <a href="http://mingw-w64.org/" rel="nofollow">MinGW-w64</a>, which
+      supports compiling both for 32- and 64-bit targets. The old <a href="http://mingw.org/" rel="nofollow">MinGW</a>
+      project only provides a 32-bit version.</p>
+    <p>The instructions below assume that you want to compile for a 64-bit target.</p>
+    <p>After installing <code>msys2</code>, first make sure that it is up-to-date. You can do so by opening an
+      <code>msys2</code> <code>bash</code> terminal and run:</p>
+    <pre><code>pacman -Syuu
+</code></pre>
+    <p>You may be requested to close and restart the <code>msys2</code> <code>bash</code> terminal at several points.
+      Please repeat executing <code>pacman -Syuu</code> until it says there are no longer any packages to update. More
+      details regarding the installation of <code>msys2</code> are available from their <a
+        href="https://github.com/msys2/msys2/wiki/MSYS2-installation">Wiki</a>.</p>
+    <p>Compilation of <code>igraph</code> requires the installation of a number of packages, namely:</p>
+    <ul>
+      <li><code>autoconf</code></li>
+      <li><code>automake</code></li>
+      <li><code>bison</code></li>
+      <li><code>flex</code></li>
+      <li><code>libtool</code></li>
+      <li><code>make</code></li>
+      <li><code>mingw-w64-x86_64-toolchain</code></li>
+      <li><code>mingw-w64-x86_64-libxml2</code></li>
+      <li><code>git</code></li>
+      <li><code>zip</code></li>
+    </ul>
+    <p>The <code>mingw-w64-x86_64-toolchain</code> also includes the optional <a href="https://gmplib.org/"
+        rel="nofollow">Gnu Multiple Precision</a> package <code>mingw-w64-x86_64-gmp</code>. This enables extended
+      functionality in igraph.</p>
+    <p>You can install these packages by running the following command in an <code>msys2</code> terminal:</p>
+    <pre><code>pacman -S autoconf automake bison flex libtool make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libxml2 mingw-w64-x86_64-gmp git zip
+</code></pre>
+    <p>Once everything is installed you need to open the <code>msys2</code> "MinGW 64-bit" terminal
+      (<code>mingw64.exe</code>).</p>
+
+    <h2><a id="user-content-compilation" class="anchor"  href="#compilation"></a>Compilation</h2>
+    <p>You can either download the <a href="https://igraph.org/c/#downloads" rel="nofollow">source code archive of the
+        latest release</a> or clone the <a href="https://github.com/igraph/igraph"><code>git</code> repository</a> using
+      <code>git clone https://github.com/igraph/igraph.git</code>. When cloning from GitHub, please ensure that you run
+      <code>git config --global core.autocrlf false</code> before cloning the repository. Otherwise, you might run into
+      problems with line endings.</p>
+    <p>After extracting the source code, open a <code>bash</code> terminal (from either <code>msys2</code> or
+      <code>cygwin</code>) and change to the directory in which the source code is located. When using
+      <code>msys2</code>, use the "MSYS2 MinGW 64-bit" terminal, and <em>not</em> the "MSYS2 MSYS" one.</p>
+    <p>If you have cloned the source code from the <code>git</code> repository, you must first create the build scripts
+      by running</p>
+    <pre><code>./bootstrap.sh
+</code></pre>
+    <p>Compilation is done with the usual steps of</p>
+    <pre><code>./configure
+make
+</code></pre>
+    <p>If you have multiple cores, for example 4, you can run <code>make -j4</code> to speed up the compilation
+      substantially.</p>
+    <p>You can install the library by running <code>make install</code>. If you prefer to install it in a specific
+      location, you can specify <code>--prefix=[DIRECTORY]</code> to <code>./configure</code>, in which case the library
+      will be installed into the <code>bin</code>, <code>lib</code> and <code>include</code> subdirectories of
+      <code>[DIRECTORY]</code>. If you just need the built <code>dll</code> file, this is located in
+      <code>src/.libs/libigraph-0.dll</code>.</p>
+    <p>You may optionally run the test suite using <code>make check</code>. Before doing this, ensure that the directory
+      containing <code>libigraph-0.dll</code> is in the <code>PATH</code>. This can be achieved for example using the
+      command</p>
+    <pre><code>export PATH=$PATH:`realpath src/.libs`
+</code></pre>
+    <h2><a id="user-content-preparing-the-msvc-project-file" class="anchor" 
+        href="#preparing-the-msvc-project-file"></a>Preparing the MSVC project file</h2>
+    <p>If you intend to compile with Microsoft Visual C++, you will need a project file for Microsoft Visual C++. This
+      can be done by following the above steps, except for the last step, you create the MSVC project file using</p>
+    <pre><code>./configure
+make msvc
+</code></pre>
+    <p>The necessary source code for compilation with MSVC is then contained in the newly created
+      <code>igraph-[VERSION]-msvc</code> directory, where <code>[VERSION]</code> refers to the version that you are
+      compiling.</p>
+    <h1><a id="user-content-compilation-using-msvc" class="anchor" 
+        href="#compilation-using-msvc"></a>Compilation using MSVC</h1>
+    <p>Compilation using MSVC is primarily necessary for use with Python, in particular for <code>python-igraph</code>.
+      Note that different versions of Python require different versions of MSVC. See <a
+        href="https://wiki.python.org/moin/WindowsCompilers" rel="nofollow">the Python website</a> for more details.</p>
+    <p>The provided project file is still provided in an older MSVC format. To use it with more recent versions of MSVC,
+      you will have to upgrade the project file. Note that this can only be done if you have the the full Microsoft
+      Visual Studio install. You can install the Community edition, which is <a
+        href="https://visualstudio.microsoft.com/downloads/" rel="nofollow">freely available</a>. The Build Tools that
+      are available do not allow you to upgrade the project file, which is necessary to be able to compile
+      <code>igraph</code> correctly.</p>
+    <p>Compilation can be done in two ways. The easiest way for most users is probably simply to open the project
+      solution file (<code>igraph.sln</code>) in the Visual Studio IDE. It will ask you to convert it to the current
+      format, and you should be able to compile it, once that is done.</p>
+    <p>Alternatively, you can compile via the command line. In that case, open the "Developer Command Prompt", and
+      depending on your version of MSVC, you should do the following</p>
+    <p>MSVC 9.0</p>
+    <pre><code>vcbuild.exe /upgrade
+vcbuild.exe igraph.vcproj "Release|x64"
+</code></pre>
+    <p>MSVC 10.0</p>
+    <pre><code>VCUpgrade.exe /overwrite ig.vcproj
+msbuild.exe igraph.vcxproj
+</code></pre>
+    <p>MSVC 14.x</p>
+    <pre><code>devenv /upgrade igraph.vcproj
+msbuild.exe igraph.vcxproj
+</code></pre>
+    <p>By default, compilation on Windows targets a static library (<code>.lib</code>), which is necessary for the
+      compilation of <code>python-igraph</code>. To import the static library, you have to make sure to specify</p>
+    <pre><code>#define IGRAPH_STATIC 1
+</code></pre>
+    <p>before you include</p>
+    <pre><code>#include "igraph.h"
+</code></pre>
+    <p>Alternatively, you can also reconfigure the MSVC project to compile a dynamic library (<code>.dll</code>), in
+      which case the <code>IGRAPH_STATIC</code> definition should <em>not</em> be included.</p>
+    <p>A small test project is included in the <code>igraphtest</code> subdirectory of the
+      <code>igraph-[VERSION]-msvc</code> directory.</p>
+    <h1><a id="user-content-compilation-problems" class="anchor" 
+        href="#compilation-problems"></a>Compilation problems</h1>
+    <p>If you have any problems with compilation on Windows, please post a message on <a
+        href="https://igraph.discourse.group/" rel="nofollow">the igraph support forum</a> or file an issue at <a
+        href="https://github.com/igraph/igraph">https://github.com/igraph/igraph</a>
+    </p>
+  </div>
+</div>

--- a/c/index.html
+++ b/c/index.html
@@ -14,12 +14,8 @@ lead: Install and start using the igraph library
             <a class="nav-link" href="#startc">Get started</a>
             <ul class="nav">
               <li class="nav-item"><a class="nav-link" href="#creq">Requirements</a></li>
-              <li class="nav-item"><a class="nav-link" href="#cinstall">Installation</a></li>
-              <li class="nav-item"><a class="nav-link" href="#cinstallosx">Installation on Mac OS X</a></li>
-              <li class="nav-item"><a class="nav-link" href="#cinstallcygwin">Installation on Windows under
-                Cygwin</a></li>
-              <li class="nav-item"><a class="nav-link" href="#cinstallmsvc">Installation using Microsoft
-                Visual C++<a></li>
+              <li class="nav-item"><a class="nav-link" href="#cinstall">Installation on Linux</a></li>
+              <li class="nav-item"><a class="nav-link" href="#cinstallwindows">Installation on Windows</a></li>
               <li class="nav-item"><a class="nav-link" href="#ctut">Tutorials</a></li>
             </ul>
           </li>
@@ -42,15 +38,15 @@ lead: Install and start using the igraph library
           <li class="nav-item">
             <a class="nav-link" href="#help">Get help</a>
             <ul class="nav">
-              <li class="nav-item"><a class="nav-link" href="#list">Mailing list</a></li>
+              <li class="nav-item"><a class="nav-link" href="#discourse">igraph support forum</a></li>
               <li class="nav-item"><a class="nav-link" href="#so">Stack Overflow</a></li>
+              <li class="nav-item"><a class="nav-link" href="#contributebugs">Report bugs</a></li>              
             </ul>
           </li>
 
           <li class="nav-item">
             <a class="nav-link" href="#contribute">Contribute</a>
             <ul class="nav">
-              <li class="nav-item"><a class="nav-link" href="#contributebugs">Report bugs</a></li>
               <li class="nav-item"><a class="nav-link" href="#contributecode">Contribute code</a></li>
             </ul>
           </li>
@@ -120,7 +116,7 @@ lead: Install and start using the igraph library
           simply install the <code>igraph</code> package.
         </p>
 
-        <h3><span id="cinstallcygwin" class="anchor">&nbsp;</span>
+        <h3><span id="cinstallwindows" class="anchor">&nbsp;</span>
           Installation on Windows</h3>
         <p>
           Preferably, you use the supplied binaries for Windows.
@@ -212,12 +208,14 @@ lead: Install and start using the igraph library
           <h1><span id="help" class="anchor">&nbsp;</span>Get help</h1>
         </div>
 
-        <h3><span id="list" class="anchor">&nbsp;</span>Discourse discussiong forum</h3>
+        <h3><span id="list" class="anchor">&nbsp;</span>igraph support forum</h3>
         <p>
           Post your question on the
           <a href="https://igraph.discourse.group">
-            igraph Discourse discussion forum
-          </a>.
+            igraph support forum
+          </a>. Make sure that you include the
+          <code>igraph</code> tag and that you include a reproducible
+          example, complete with code and data.
         </p>
 
         <h3><span id="so" class="anchor">&nbsp;</span>Stack Overflow</h3>
@@ -229,20 +227,20 @@ lead: Install and start using the igraph library
           example, complete with code and data.
         </p>
 
-        <div class="page-header">
-          <h1><span id="contribute" class="anchor">&nbsp;</span>Contribute</h1>
-        </div>
-
-        <p>
-          Your contribution is more than welcome!
-        </p>
-
         <h3><span id="contributebugs" class="anchor">&nbsp;</span>
           Report bugs</h3>
 
         <p>Report bugs or suggest new features or algorithms in the
           <a href="https://github.com/igraph/igraph/issues">
           GitHub issue tracker</a>.
+        </p>
+
+        <div class="page-header">
+          <h1><span id="contribute" class="anchor">&nbsp;</span>Contribute</h1>
+        </div>
+
+        <p>
+          Your contribution is more than welcome!
         </p>
 
         <!-- <h3><span id="contributewiki" class="anchor">&nbsp;</span> -->

--- a/c/index.html
+++ b/c/index.html
@@ -66,40 +66,48 @@ lead: Install and start using the igraph library
             Get started</h1>
         </div>
 
-        <h3><span id="creq" class="anchor">&nbsp;</span>Requirements</h3>
+        <h3><span id="cinstall" class="anchor">&nbsp;</span>Installation on Linux</h3>
         <p>
           Make sure you have the following before installing igraph:
           <ul>
-            <li>A <strong>Linux</strong>, <strong>Mac OS X</strong> or
-              <strong>MS Windows</strong> system. Other
+            <li>A <strong>Linux</strong> system, such as Ubuntu or Debian. Other
               Unix and similar systems probably work as well,
               e.g. Oracle Solaris, BSD systems, etc.</li>
             <li>C and C++ compilers, <code>gcc</code>,
               <code>clang</code> or others.</li>
             <li>The GNU <code>make</code> tool.</li>
-            <li>Optionally the <a href="http://www.xmlsoft.org/"> 
+            <li>Optionally the <a href="https://www.xmlsoft.org/">
               <code>libxml2</code></a> library for reading GraphML
-              files.</li> 
+              files.</li>
+            <li>Optionally the <a href="https://gmplib.org/">
+                <code>GMP</code></a> library to support arbitrary
+                precision arithmetic.</li>
           </ul>
           On Ubuntu and Debian Linux, installing the
-          <code>build-essential</code> and the
-          <code>libxml2-dev</code> packages is sufficient.
+          <code>build-essential</code> and optionally the
+          <code>libxml2-dev</code> and
+          <code>libgmp-dev</code>
+          packages is sufficient.
         </p>
-
-        <h3><span id="cinstall" class="anchor">&nbsp;</span>Installation</h3>
         <p>
           The standard installation method uses the
           <code>autoconf</code>/<code>automake</code> toolset. After
-          downloading and uncompression the source code run the
+          downloading and uncompressing the release source code run the
           following commands from the top-level directory of the code.
         </p>
         <p>
           {% highlight sh %}
- ./configure
- make
- make check
- make install  {% endhighlight %}
+          ./configure
+          make
+          make check
+          make install
+          {% endhighlight %}
         </p>
+        <p>
+          When compiling code directly from the <a href="https://github.com/igraph/igraph">GitHub repository</a>, the <code>./configure</code>
+          script should first be generated using <code>./bootstrap.sh</code>.
+        </p>
+
         <p>The <code>make check</code> step is optional, but it is
           useful to spot problems early on.
         </p>
@@ -107,40 +115,28 @@ lead: Install and start using the igraph library
         <h3><span id="cinstallosx" class="anchor">&nbsp;</span>
           Installation on Mac OS X</h3>
         <p>
-          You can use the regular Unix way (as above), or
-          if you have <a href="http://brew.sh/">Homebrew</a>, then
-          simply install the <code>igraph</code> formula.
+          You can use the regular Linux way (as above), or
+          if you have <a href="https://brew.sh/">Homebrew</a> or <a href="https://www.macports.org/">MacPorts</a>, then
+          simply install the <code>igraph</code> package.
         </p>
 
         <h3><span id="cinstallcygwin" class="anchor">&nbsp;</span>
-          Installation on Windows under Cygwin</h3>
+          Installation on Windows</h3>
         <p>
-          One way to install igraph on Windows is to use 
-          <a href="http://www.cygwin.com/">Cygwin</a>. From a Cygwin
-          shell, use the standard installation method, as
-          above.
-        </p>
-
-        <h3><span id="cinstallmsvc" class="anchor">&nbsp;</span>
-          Installation on Windows using Microsoft Visual C++</h3>
-        <p>
-          It is also possible to use Microsoft Visual C++
-          (MSVC). Download the ZIP file made for MSVC, uncompress it,
-          and open the solution file <code>igraph.sln</code> from
-          MSVC. You can build the library the usual way then. For
-          GraphML support you'll need to install the
-          <code>libxml2</code> library by hand, see the 
-          <a href="http://www.zlatkovic.com/libxml.en.html">
-            Windows port</a> of <code>libxml2</code>.
+          Preferably, you use the supplied binaries for Windows.
+          We supply both binaries compiled with MSVC and MinGW-64.
+          Compilation on Windows involves a number of more detailed steps,
+          please see <a href="compilation-windows.html">this explanation</a>
+          for more details.
         </p>
 
         <h3><span id="ctut" class="anchor">&nbsp;</span>Tutorials</h3>
         <p>
           <ul>
-            <li>The source code comes with some examples (also used
+            <li>The source code comes with some examples (some of which are also used
               for testing). You can find them in the
               <code>examples/simple</code> directory.</li>
-            <li>Most of the examples are also included in the 
+            <li>Most of the examples are also included in the
               <a href="/c/doc/">Reference Manual</a>.
           </ul>
         </p>
@@ -216,14 +212,12 @@ lead: Install and start using the igraph library
           <h1><span id="help" class="anchor">&nbsp;</span>Get help</h1>
         </div>
 
-        <h3><span id="list" class="anchor">&nbsp;</span>Mailing list</h3>
+        <h3><span id="list" class="anchor">&nbsp;</span>Discourse discussiong forum</h3>
         <p>
-          Post a question on the
-          <a href="https://lists.nongnu.org/mailman/listinfo/igraph-help">
-            igraph-help mailing list</a>. To avoid spam
-          on the list, you need to sign up first. You can also 
-          <a href="http://lists.nongnu.org/archive/html/igraph-help/">
-          search the mailing list.</a>
+          Post your question on the
+          <a href="https://igraph.discourse.group">
+            igraph Discourse discussion forum
+          </a>.
         </p>
 
         <h3><span id="so" class="anchor">&nbsp;</span>Stack Overflow</h3>
@@ -242,18 +236,18 @@ lead: Install and start using the igraph library
         <p>
           Your contribution is more than welcome!
         </p>
-        
+
         <h3><span id="contributebugs" class="anchor">&nbsp;</span>
           Report bugs</h3>
 
-        <p>Report bugs or suggest new features or algorithms in the 
+        <p>Report bugs or suggest new features or algorithms in the
           <a href="https://github.com/igraph/igraph/issues">
           GitHub issue tracker</a>.
         </p>
-        
+
         <!-- <h3><span id="contributewiki" class="anchor">&nbsp;</span> -->
         <!--   Improve the wiki</h3> -->
-        
+
         <!-- <p>Add your work to the gallery in the -->
         <!--   <a href="https://github.com/igraph/igraph/wiki"> -->
         <!--         igraph wiki</a>. -->
@@ -261,7 +255,7 @@ lead: Install and start using the igraph library
 
         <h3><span id="contributecode" class="anchor">&nbsp;</span>
           Contribute code</h3>
-          
+
         <p>Send a pull request on <a href="https://github.com/igraph/igraph">
                 GitHub.</a> Please note that igraph can contain only
           code that is compatible with its GPL license. See

--- a/c/index.html
+++ b/c/index.html
@@ -15,6 +15,7 @@ lead: Install and start using the igraph library
             <ul class="nav">
               <li class="nav-item"><a class="nav-link" href="#creq">Requirements</a></li>
               <li class="nav-item"><a class="nav-link" href="#cinstall">Installation on Linux</a></li>
+              <li class="nav-item"><a class="nav-link" href="#cinstallosx">Installation on macOS</a></li>
               <li class="nav-item"><a class="nav-link" href="#cinstallwindows">Installation on Windows</a></li>
               <li class="nav-item"><a class="nav-link" href="#ctut">Tutorials</a></li>
             </ul>
@@ -109,7 +110,7 @@ lead: Install and start using the igraph library
         </p>
 
         <h3><span id="cinstallosx" class="anchor">&nbsp;</span>
-          Installation on Mac OS X</h3>
+          Installation on macOS</h3>
         <p>
           You can use the regular Linux way (as above), or
           if you have <a href="https://brew.sh/">Homebrew</a> or <a href="https://www.macports.org/">MacPorts</a>, then

--- a/c/index.html
+++ b/c/index.html
@@ -214,8 +214,7 @@ lead: Install and start using the igraph library
           Post your question on the
           <a href="https://igraph.discourse.group">
             igraph support forum
-          </a>. Make sure that you include the
-          <code>igraph</code> tag and that you include a reproducible
+          </a>. Make sure that you include a minimal reproducible
           example, complete with code and data.
         </p>
 
@@ -224,7 +223,7 @@ lead: Install and start using the igraph library
           Post specific igraph questions on
           <a href="http://stackoverflow.com/questions/tagged/igraph">
             Stack Overflow</a>. Make sure that you include the
-          <code>igraph</code> tag and that you include a reproducible
+          <code>igraph</code> tag and that you include a minimal reproducible
           example, complete with code and data.
         </p>
 


### PR DESCRIPTION
DO NOT MERGE YET.

I already started editing the website. I already wanted to share this with you, so that it is clear that work is already being done. 

I still have to include the the installation instructions for Windows. I will do that later (so the link to those specific instructions for Windows is not yet working). @ntamas, I believe you said I could simply use Markdown, but wouldn't it be easier if I would just add the `compilations-windows.html` as I've included it now?

By the way, the release source code now refers to nightly builds. There are two things related to this: (1) we should link specifically to the released code; and (2) will we indeed provide nightly builds? Regarding nightly builds, perhaps it is best to simply always provide a source package for the latest master, but also clearly indicate the version (instead of simply nightly). That way, any reported issue can always be traced back more easily to an exact version.

Regarding the version that is reported, `{% include igraph-cversion %}` is now used for that, but on the website it simply seems to be replaced by `master`, not by the actual version, `0.8.0-pre+9b27241` (or whatever version exactly). This should be corrected still
