### PR TITLE
Shuffled some sections. Removed mention of binaries.

### DIFF
--- a/c/index.html
+++ b/c/index.html
@@ -13,17 +13,16 @@ lead: Install and start using the igraph library
           <li class="nav-item">
             <a class="nav-link" href="#startc">Get started</a>
             <ul class="nav">
-              <li class="nav-item"><a class="nav-link" href="#creq">Requirements</a></li>
+              <li class="nav-item"><a class="nav-link" href="#cinstallwindows">Installation on Windows</a></li>
               <li class="nav-item"><a class="nav-link" href="#cinstall">Installation on Linux</a></li>
               <li class="nav-item"><a class="nav-link" href="#cinstallosx">Installation on macOS</a></li>
-              <li class="nav-item"><a class="nav-link" href="#cinstallwindows">Installation on Windows</a></li>
-              <li class="nav-item"><a class="nav-link" href="#ctut">Tutorials</a></li>
             </ul>
           </li>
 
           <li class="nav-item">
             <a class="nav-link" href="#docs">Documentation</a>
             <ul class="nav">
+              <li class="nav-item"><a class="nav-link" href="#ctut">Tutorials</a></li>
               <li class="nav-item"><a class="nav-link" href="#cmanual">C reference manual</a></li>
             </ul>
           </li>
@@ -41,7 +40,7 @@ lead: Install and start using the igraph library
             <ul class="nav">
               <li class="nav-item"><a class="nav-link" href="#discourse">igraph support forum</a></li>
               <li class="nav-item"><a class="nav-link" href="#so">Stack Overflow</a></li>
-              <li class="nav-item"><a class="nav-link" href="#contributebugs">Report bugs</a></li>              
+              <li class="nav-item"><a class="nav-link" href="#contributebugs">Report bugs</a></li>
             </ul>
           </li>
 
@@ -62,6 +61,14 @@ lead: Install and start using the igraph library
           <h1><span id="startc" class="anchor">&nbsp;</span>
             Get started</h1>
         </div>
+
+        <h3><span id="cinstallwindows" class="anchor">&nbsp;</span>
+          Installation on Windows</h3>
+        <p>
+          Compilation on Windows involves a number of more detailed steps,
+          please see <a href="compilation-windows.html">this explanation</a>
+          for more details.
+        </p>
 
         <h3><span id="cinstall" class="anchor">&nbsp;</span>Installation on Linux</h3>
         <p>
@@ -117,15 +124,10 @@ make install
           simply install the <code>igraph</code> package.
         </p>
 
-        <h3><span id="cinstallwindows" class="anchor">&nbsp;</span>
-          Installation on Windows</h3>
-        <p>
-          Preferably, you use the supplied binaries for Windows.
-          We supply both binaries compiled with MSVC and MinGW-64.
-          Compilation on Windows involves a number of more detailed steps,
-          please see <a href="compilation-windows.html">this explanation</a>
-          for more details.
-        </p>
+        <div class="page-header">
+          <h1><span id="docs" class="anchor">&nbsp;</span>Documentation
+          <small>&ndash; for version {% include igraph-cversion %}</small></h1>
+        </div>
 
         <h3><span id="ctut" class="anchor">&nbsp;</span>Tutorials</h3>
         <p>
@@ -137,11 +139,6 @@ make install
               <a href="/c/doc/">Reference Manual</a>.
           </ul>
         </p>
-
-        <div class="page-header">
-          <h1><span id="docs" class="anchor">&nbsp;</span>Documentation
-          <small>&ndash; for version {% include igraph-cversion %}</small></h1>
-        </div>
 
         <h3><span id="cmanual" class="anchor">&nbsp;</span>
           C Reference Manual</h3>


### PR DESCRIPTION
I removed the mention of binaries for Windows. I also removed the link to Requirements, which are no longer there. Finally, I put the tutorials section under "documentation", instead of under "get started".