### PR TITLE
Add forum link in header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,6 +73,9 @@
           <li class="nav-item">
             <a class="nav-link" href="/news.html"><i class="fa fa-rss"></i> News</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://igraph.discourse.group"><i class="fa fa-comments"></i> Forum</a>
+          </li>		
           <li class-"nav-item">
             <a class="nav-link" href="https://github.com/igraph"><i class="fa fa-github"></i> On GitHub</a>
           </li>


### PR DESCRIPTION
I wasn't quite able to test this, so be careful! I'm not experienced with webby stuff.

Font Awesome has a Discourse icon, but not in version 4.7 which is used here. So I used the Comments icon.