### PR TITLE
Remove :tada: in announcement.

### DIFF
--- a/_posts/2020-03-16-igraph-0.8.1-c.markdown
+++ b/_posts/2020-03-16-igraph-0.8.1-c.markdown
@@ -4,7 +4,7 @@ date: 2020-03-16
 tags: c
 ---
 
-We are happy to announce the first bugfix release of the 0.8 series of [igraph's C core](https://igraph.org/c/)! 🎉
+We are happy to announce the first bugfix release of the 0.8 series of [igraph's C core](https://igraph.org/c/)!
 
 The sources can be obtained from [the GitHub releases page](https://github.com/igraph/igraph/releases/tag/0.8.1).
 


### PR DESCRIPTION
The :tada: is not rendering correctly on the website in the announcement of version 0.8.1