### PR TITLE
doc(C): corrected version for download.

### DIFF
--- a/docs/c/index.html
+++ b/docs/c/index.html
@@ -291,9 +291,9 @@ make install
         <p>
           <ul class="icons-ul list-unstyled">
             <li><i class="icon-li icon-file-text"></i>
-              <a href="https://github.com/igraph/igraph/releases/download/0.8.0/igraph-0.8.1.tar.gz">Source code</a></li>
+              <a href="https://github.com/igraph/igraph/releases/download/0.8.1/igraph-0.8.1.tar.gz">Source code</a></li>
             <li><i class="icon-li icon-windows"></i>
-              <a href="https://github.com/igraph/igraph/releases/download/0.8.0/igraph-0.8.1-msvc.zip">Source code for Microsoft Visual
+              <a href="https://github.com/igraph/igraph/releases/download/0.8.1/igraph-0.8.1-msvc.zip">Source code for Microsoft Visual
               Studio</a></li>
           </ul>
         </p>


### PR DESCRIPTION
The version for downloading the source code was incorrectly pointing to 0.8.0 still, as was remarked [here](https://igraph.discourse.group/t/incorrect-download-links-on-the-main-c-igraph-page/189).