### PR TITLE
Redirect default python link to RTD page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,12 @@ PYVERSION?=0.10.1
 # Available versions
 CVERSIONS   ?= '0.9.0 0.9.4 0.9.5 0.9.6 0.9.7 0.9.8 0.9.9 0.9.10 0.10.0 0.10.1 0.10.2 master develop'
 RVERSIONS   ?= '1.2.3 1.2.4 1.2.5 1.2.6 1.2.7 1.3.0 1.3.1 1.3.2 1.3.3 1.3.4 1.3.5'
-PYVERSIONS  ?= '0.9.6 0.9.7 0.9.8 0.9.9 0.9.10 0.9.11 0.10.0 0.10.1 master develop'
-PYCVERSIONS ?= '0.9.4 0.9.4 0.9.4 0.9.6  0.9.8  0.9.9 0.10.0 0.10.1 master develop'
+PYVERSIONS  ?= '0.9.6 0.9.7 0.9.8 0.9.9 0.9.10 0.9.11 0.10.0 0.10.1'
+PYCVERSIONS ?= '0.9.4 0.9.4 0.9.4 0.9.6  0.9.8  0.9.9 0.10.0 0.10.1'
 
 # FIXME: this is broken now
 # optional variable so we can update the C docs without making a release
 # CCOMMITHASH?=8bca587ad
-# optional variable so we can update the Python docs without making a release
-# PYCOMMITHASH?=9bde4c29f
 
 CREPO=https://github.com/igraph/igraph
 RREPO=https://github.com/igraph/rigraph

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -19,7 +19,7 @@ animated_header: true
     </p>
     <hr class="my-4">
     <a href="/r" class="btn btn-lg btn-dark">igraph R package</a>
-    <a href="/python/versions/latest" class="btn btn-lg btn-dark">python-igraph</a>
+    <a href="https://igraph.readthedocs.io/" class="btn btn-lg btn-dark">python-igraph</a>
     <a href="http://szhorvat.net/mathematica/IGraphM" class="btn btn-lg btn-dark">IGraph/M</a>
     <a href="/c" class="btn btn-lg btn-dark">igraph C library</a>
   </div>

--- a/python/index.html
+++ b/python/index.html
@@ -5,12 +5,12 @@ mainheader: python-igraph manual
 lead: For using igraph from Python
 ---
 
-You will be redirected to the <a href="/python/versions/latest/">documentation page of
+You will be redirected to the <a href="https://igraph.readthedocs.io/">documentation page of
 the Python interface</a> soon. Click on the link if the redirect did not work
 or if you have JavaScript turned off.
 
 {% raw %}
 <script>
-window.location.replace("/python/versions/latest/");
+window.location.replace("https://igraph.readthedocs.io/");
 </script>
 {% endraw %}


### PR DESCRIPTION
Whenever we are ready to switch over these links.

We should probably wait until the next Python stable release (0.10.2) so we can set that tag as the default landing for RTD. When that lands, we can merge this, regenerate the docs, and push them online.